### PR TITLE
Added path to API explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,20 @@ OUTPUT_DIR = bin
 OBJ_DIR = obj
 
 ROOT_DIR := $(shell pwd)
+API_DIR := $(ROOT_DIR)/Api
 
 TARGET_LIB = $(OUTPUT_DIR)/vl53l0x_python
 
 INCLUDES = \
 	-I$(ROOT_DIR) \
-	-I${API_DIR}/Api/core/inc \
+	-I$(API_DIR)/core/inc \
 	-I$(ROOT_DIR)/platform/inc
 
 PYTHON_INCLUDES = \
     -I/usr/include/python2.7
 
 VPATH = \
-	${API_DIR}/Api/core/src \
+	$(API_DIR)/core/src \
 	$(ROOT_DIR)/platform/src/ \
 	$(ROOT_DIR)/python_lib
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Notes on Multiple sensor support:
 
 ### Compilation
 
-* To compile the lib on your raspberry pi:
+* To compile the lib on your raspberry pi use following commands:
 ```bash
 API_DIR=path/to/the/api/dir make
 ```
@@ -37,6 +37,11 @@ API_DIR=path/to/the/api/dir make
 VL53L0X.py - This contains the python ctypes interface to the ST Library
 
 VL53L0X_example.py - This contains an example that accesses a single sensor with the default address.
+
+VL53L0X_example_livegraph.py - This examples plots the distance data from the sensor in a live graph.
+
+Note: This example requires matplotlib. Use `sudo pip install matplotlib` to install matplotlib.
+      Also, this would need to be run using VNC on headless RPi nodes.
 
 VL53L0X_multi_example.py - This contains an example that accesses 2 sensors, setting the first to address 0x2B an the second to address 0x2D. It uses GPIOs 20 and 16 connected to the shutdown pins on the 2 sensors to control sensor activation.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Notes on Multiple sensor support:
 
 * To compile the lib on your raspberry pi use following commands:
 ```bash
-API_DIR=path/to/the/api/dir make
+cd ~
+git clone https://github.com/johnbryanmoore/VL53L0X_rasp_python.git
+cd VL53L0X_rasp_python
+make
 ```
 
 * In the Python directory are 2 python files:

--- a/python/VL53L0X_example_livegraph.py
+++ b/python/VL53L0X_example_livegraph.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# MIT License
+# 
+# Copyright (c) 2017 John Bryan Moore, Sampath Vanimisetti
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+import time
+import VL53L0X
+
+fig = plt.figure()
+ax1 = fig.add_subplot(1,1,1)
+
+xarr = []
+yarr = []
+count = 0
+
+def animate(i):
+    global count
+    distance = tof.get_distance()
+    count = count + 1
+    xarr.append(count)
+    yarr.append(distance)
+    time.sleep(timing/1000000.00)
+    ax1.clear()
+    ax1.plot(xarr,yarr)
+
+# Create a VL53L0X object
+tof = VL53L0X.VL53L0X()
+
+# Start ranging
+tof.start_ranging(VL53L0X.VL53L0X_BETTER_ACCURACY_MODE)
+
+timing = tof.get_timing()
+if (timing < 20000):
+    timing = 20000
+print ("Timing %d ms" % (timing/1000))
+
+print ("Press ctrl-c to exit")
+
+ani = animation.FuncAnimation(fig, animate, interval=100)
+plt.show()
+
+tof.stop_ranging()


### PR DESCRIPTION
API path explicitly added to makefile rather than relying on the environment variable (export API_DIR=<path-to-api>). Assumption here is that the API directory resides inside the main directory.