### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = $(CROSS_COMPILE)gcc
 RM = rm
 
 #CFLAGS = -O0 -g -Wall -c
-CFLAGS = -O2 -Wall -c
+CFLAGS = -O2 -Wall -c -fPIC
 
 OUTPUT_DIR = bin
 OBJ_DIR = obj


### PR DESCRIPTION
Make was failing on a vanilla Ubuntu Mate 16.04 LTS image on a RPi3. 

```
$ sudo make
mkdir -p obj/
gcc -O2 -Wall -c -I/usr/include/python2.7 -I/home/tom/Downloads/VL53L0X_rasp_python -I/home/tom/Downloads/VL53L0X_rasp_python/Api/core/inc -I/home/tom/Downloads/VL53L0X_rasp_python/platform/inc /home/tom/Downloads/VL53L0X_rasp_python/Api/core/src/vl53l0x_api_calibration.c -o obj/vl53l0x_api_calibration.o
mkdir -p obj/
gcc -O2 -Wall -c -I/usr/include/python2.7 -I/home/tom/Downloads/VL53L0X_rasp_python -I/home/tom/Downloads/VL53L0X_rasp_python/Api/core/inc -I/home/tom/Downloads/VL53L0X_rasp_python/platform/inc /home/tom/Downloads/VL53L0X_rasp_python/Api/core/src/vl53l0x_api_core.c -o obj/vl53l0x_api_core.o
mkdir -p obj/
gcc -O2 -Wall -c -I/usr/include/python2.7 -I/home/tom/Downloads/VL53L0X_rasp_python -I/home/tom/Downloads/VL53L0X_rasp_python/Api/core/inc -I/home/tom/Downloads/VL53L0X_rasp_python/platform/inc /home/tom/Downloads/VL53L0X_rasp_python/Api/core/src/vl53l0x_api_ranging.c -o obj/vl53l0x_api_ranging.o
mkdir -p obj/
gcc -O2 -Wall -c -I/usr/include/python2.7 -I/home/tom/Downloads/VL53L0X_rasp_python -I/home/tom/Downloads/VL53L0X_rasp_python/Api/core/inc -I/home/tom/Downloads/VL53L0X_rasp_python/platform/inc /home/tom/Downloads/VL53L0X_rasp_python/Api/core/src/vl53l0x_api_strings.c -o obj/vl53l0x_api_strings.o
mkdir -p obj/
gcc -O2 -Wall -c -I/usr/include/python2.7 -I/home/tom/Downloads/VL53L0X_rasp_python -I/home/tom/Downloads/VL53L0X_rasp_python/Api/core/inc -I/home/tom/Downloads/VL53L0X_rasp_python/platform/inc /home/tom/Downloads/VL53L0X_rasp_python/Api/core/src/vl53l0x_api.c -o obj/vl53l0x_api.o
mkdir -p obj/
gcc -O2 -Wall -c -I/usr/include/python2.7 -I/home/tom/Downloads/VL53L0X_rasp_python -I/home/tom/Downloads/VL53L0X_rasp_python/Api/core/inc -I/home/tom/Downloads/VL53L0X_rasp_python/platform/inc /home/tom/Downloads/VL53L0X_rasp_python/platform/src/vl53l0x_platform.c -o obj/vl53l0x_platform.o
mkdir -p obj/
gcc -O2 -Wall -c -I/usr/include/python2.7 -I/home/tom/Downloads/VL53L0X_rasp_python -I/home/tom/Downloads/VL53L0X_rasp_python/Api/core/inc -I/home/tom/Downloads/VL53L0X_rasp_python/platform/inc /home/tom/Downloads/VL53L0X_rasp_python/python_lib/vl53l0x_python.c -o obj/vl53l0x_python.o
mkdir -p bin/
gcc -shared obj/vl53l0x_api_calibration.o obj/vl53l0x_api_core.o obj/vl53l0x_api_ranging.o obj/vl53l0x_api_strings.o obj/vl53l0x_api.o obj/vl53l0x_platform.o obj/vl53l0x_python.o -I/usr/include/python2.7 -I/home/tom/Downloads/VL53L0X_rasp_python -I/home/tom/Downloads/VL53L0X_rasp_python/Api/core/inc -I/home/tom/Downloads/VL53L0X_rasp_python/platform/inc -lpthread -o bin/vl53l0x_python.so
/usr/bin/ld: obj/vl53l0x_api_calibration.o: relocation R_ARM_THM_MOVW_ABS_NC against `__stack_chk_guard' can not be used when making a shared object; recompile with -fPIC
obj/vl53l0x_api_calibration.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:44: recipe for target 'bin/vl53l0x_python' failed
```

Added -fPIC as instructed and compiled and executed ok.