### PR TITLE
Use smbus2

### DIFF
--- a/python/VL53L0X.py
+++ b/python/VL53L0X.py
@@ -24,7 +24,7 @@
 
 import time
 from ctypes import *
-import smbus
+import smbus2
 
 VL53L0X_GOOD_ACCURACY_MODE      = 0   # Good Accuracy mode
 VL53L0X_BETTER_ACCURACY_MODE    = 1   # Better Accuracy mode
@@ -32,7 +32,7 @@ VL53L0X_BEST_ACCURACY_MODE      = 2   # Best Accuracy mode
 VL53L0X_LONG_RANGE_MODE         = 3   # Longe Range mode
 VL53L0X_HIGH_SPEED_MODE         = 4   # High Speed mode
 
-i2cbus = smbus.SMBus(1)
+i2cbus = smbus2.SMBus(1)
 
 # i2c bus read callback
 def i2c_read(address, reg, data_p, length):


### PR DESCRIPTION
[smbus2](https://github.com/kplindegaard/smbus2) is pure Python implementation of the python-smbus package.

> Use the inherent i2c structs and unions to a greater extent than other pure Python implementations like pysmbus does. By doing so, it will be more feature complete and easier to extend.