### PR TITLE
Fixed "i2c_address * 2" bug

### DIFF
--- a/Api/core/src/vl53l0x_api.c
+++ b/Api/core/src/vl53l0x_api.c
@@ -358,7 +358,7 @@ VL53L0X_Error VL53L0X_SetDeviceAddress(VL53L0X_DEV Dev, uint8_t DeviceAddress)
 	LOG_FUNCTION_START("");
 
 	Status = VL53L0X_WrByte(Dev, VL53L0X_REG_I2C_SLAVE_DEVICE_ADDRESS,
-		DeviceAddress / 2);
+		DeviceAddress);
 
 	LOG_FUNCTION_END(Status);
 	return Status;

--- a/Api/core/src/vl53l0x_api.c.bak
+++ b/Api/core/src/vl53l0x_api.c.bak
@@ -358,7 +358,7 @@ VL53L0X_Error VL53L0X_SetDeviceAddress(VL53L0X_DEV Dev, uint8_t DeviceAddress)
 	LOG_FUNCTION_START("");
 
 	Status = VL53L0X_WrByte(Dev, VL53L0X_REG_I2C_SLAVE_DEVICE_ADDRESS,
-		DeviceAddress / 2);
+		DeviceAddress);
 
 	LOG_FUNCTION_END(Status);
 	return Status;

--- a/python_lib/vl53l0x_python.c
+++ b/python_lib/vl53l0x_python.c
@@ -194,10 +194,7 @@ void startRanging(int object_number, int mode, uint8_t i2c_address, uint8_t TCA9
                 // Address requested not default so set the address.
                 // This assumes that the shutdown pin has been controlled
                 // externally to this function.
-                // TODO: Why does this function divide the address by 2? To get 
-                // the address we want we have to mutiply by 2 in the call so
-                // it gets set right
-                Status = VL53L0X_SetDeviceAddress(pMyDevice[object_number], (i2c_address * 2));
+                Status = VL53L0X_SetDeviceAddress(pMyDevice[object_number], (i2c_address));
                 pMyDevice[object_number]->I2cDevAddr      = i2c_address;
             }
 


### PR DESCRIPTION
TODO in python_lib\vl53l0x_python.c mentioned bug resulting in output of VL53L0X_SetDeviceAddress() having to multiple desired i2c_address by 2 in order to get correct address assigned to the sensor. Located bug in the API function where the device address was being arbitrarily being divided by 2 before being assigned to the sensor.